### PR TITLE
fixed an error during the 2nd installation of capstone 

### DIFF
--- a/linux64/bootstrap.sh
+++ b/linux64/bootstrap.sh
@@ -42,7 +42,7 @@ sudo -u vagrant wget -O ~vagrant/.gdbinit 'https://raw.githubusercontent.com/gdb
 sudo pip2 uninstall capstone -y
 
 # Install correct capstone
-cd ~/tools/capstone/bindings/python
+cd /home/vagrant/capstone/bindings/python
 sudo python setup.py install
 
 # disable ASRL


### PR DESCRIPTION
by specifying the correct path. during the installation it was searching in the root home instead of the vagrant home
